### PR TITLE
Resolvido erro no pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -56,7 +56,6 @@
 			<artifactId>spring-boot-starter-test</artifactId>
 			<scope>test</scope>
 		</dependency>
-	</dependencies>
 
         <dependency>
             <groupId>org.springframework.boot</groupId>


### PR DESCRIPTION
Após resolver conflitos no merge, o arquivo pom.xml permaneceu com a tag </dependencies> no meio do arquivo, tirando da inclusão algumas outras dependencias e gerando conflito.